### PR TITLE
Add support for ears

### DIFF
--- a/lib/java_buildpack/container/jboss.rb
+++ b/lib/java_buildpack/container/jboss.rb
@@ -58,7 +58,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        web_inf? && !JavaBuildpack::Util::JavaMainUtils.main_class(@application)
+        (web_inf? && !JavaBuildpack::Util::JavaMainUtils.main_class(@application)) || ear?
       end
 
       private
@@ -97,6 +97,10 @@ module JavaBuildpack
 
       def web_inf?
         (@application.root + 'WEB-INF').exist?
+      end
+
+      def ear?
+        (@application.root + 'META-INF/application.xml').exist?
       end
 
     end

--- a/lib/java_buildpack/container/jboss.rb
+++ b/lib/java_buildpack/container/jboss.rb
@@ -70,7 +70,6 @@ module JavaBuildpack
 
       def copy_additional_libraries
         if ear?
-          FileUtils.mkdir_p root + "/lib"
           meta_inf_lib = root + "/lib"
           @droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, meta_inf_lib }
         else

--- a/lib/java_buildpack/container/jboss.rb
+++ b/lib/java_buildpack/container/jboss.rb
@@ -70,8 +70,8 @@ module JavaBuildpack
 
       def copy_additional_libraries
         if ear?
-          FileUtils.mkdir_p @application.root + "/lib"
-          meta_inf_lib = @application.root + "/lib"
+          FileUtils.mkdir_p root + "/lib"
+          meta_inf_lib = root + "/lib"
           @droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, meta_inf_lib }
         else
           web_inf_lib = root + 'WEB-INF/lib'

--- a/lib/java_buildpack/container/jboss.rb
+++ b/lib/java_buildpack/container/jboss.rb
@@ -70,7 +70,7 @@ module JavaBuildpack
 
       def copy_additional_libraries
         if ear?
-          meta_inf_lib = root + "/lib"
+          meta_inf_lib = root + "lib"
           #@droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, meta_inf_lib }
         else
           web_inf_lib = root + 'WEB-INF/lib'

--- a/lib/java_buildpack/container/jboss.rb
+++ b/lib/java_buildpack/container/jboss.rb
@@ -68,11 +68,10 @@ module JavaBuildpack
         @application.root.children.each { |child| FileUtils.cp_r child, root }
       end
 
-      # getting permission error here after adding ear code.  Did this ever work?
       def copy_additional_libraries
         if ear?
           meta_inf_lib = root + "/lib"
-          @droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, meta_inf_lib }
+          #@droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, meta_inf_lib }
         else
           web_inf_lib = root + 'WEB-INF/lib'
           @droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, web_inf_lib }

--- a/lib/java_buildpack/container/jboss.rb
+++ b/lib/java_buildpack/container/jboss.rb
@@ -69,8 +69,13 @@ module JavaBuildpack
       end
 
       def copy_additional_libraries
-        web_inf_lib = root + 'WEB-INF/lib'
-        @droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, web_inf_lib }
+        if ear?
+          meta_inf_lib = root + "/lib"
+          @droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, meta_inf_lib }
+        else
+          web_inf_lib = root + 'WEB-INF/lib'
+          @droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, web_inf_lib }
+        end
       end
 
       def create_dodeploy

--- a/lib/java_buildpack/container/jboss.rb
+++ b/lib/java_buildpack/container/jboss.rb
@@ -70,8 +70,8 @@ module JavaBuildpack
 
       def copy_additional_libraries
         if ear?
-          FileUtils.mkdir_p root + "/lib"
-          meta_inf_lib = root + "/lib"
+          FileUtils.mkdir_p @application.root + "/lib"
+          meta_inf_lib = @application.root + "/lib"
           @droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, meta_inf_lib }
         else
           web_inf_lib = root + 'WEB-INF/lib'

--- a/lib/java_buildpack/container/jboss.rb
+++ b/lib/java_buildpack/container/jboss.rb
@@ -80,11 +80,19 @@ module JavaBuildpack
       end
 
       def create_dodeploy
-        FileUtils.touch(webapps + 'ROOT.war.dodeploy')
+        if ear?
+          FileUtils.touch(webapps + 'ROOT.ear.dodeploy')
+        else
+          FileUtils.touch(webapps + 'ROOT.war.dodeploy')
+        end
       end
 
       def root
-        webapps + 'ROOT.war'
+        if ear?
+          webapps + 'ROOT.ear'
+        else
+          webapps + 'ROOT.war'
+        end
       end
 
       def update_configuration

--- a/lib/java_buildpack/container/jboss.rb
+++ b/lib/java_buildpack/container/jboss.rb
@@ -70,6 +70,7 @@ module JavaBuildpack
 
       def copy_additional_libraries
         if ear?
+          FileUtils.mkdir_p root + "/lib"
           meta_inf_lib = root + "/lib"
           @droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, meta_inf_lib }
         else

--- a/lib/java_buildpack/container/jboss.rb
+++ b/lib/java_buildpack/container/jboss.rb
@@ -32,7 +32,7 @@ module JavaBuildpack
         download_tar
         update_configuration
         copy_application
-        copy_additional_libraries
+        #copy_additional_libraries
         create_dodeploy
       end
 
@@ -68,6 +68,7 @@ module JavaBuildpack
         @application.root.children.each { |child| FileUtils.cp_r child, root }
       end
 
+      # getting permission error here after adding ear code.  Did this ever work?
       def copy_additional_libraries
         if ear?
           meta_inf_lib = root + "/lib"

--- a/lib/java_buildpack/container/jboss.rb
+++ b/lib/java_buildpack/container/jboss.rb
@@ -32,7 +32,7 @@ module JavaBuildpack
         download_tar
         update_configuration
         copy_application
-        #copy_additional_libraries
+        copy_additional_libraries
         create_dodeploy
       end
 

--- a/lib/java_buildpack/container/jboss.rb
+++ b/lib/java_buildpack/container/jboss.rb
@@ -71,7 +71,7 @@ module JavaBuildpack
       def copy_additional_libraries
         if ear?
           meta_inf_lib = root + "lib"
-          #@droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, meta_inf_lib }
+          @droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, meta_inf_lib }
         else
           web_inf_lib = root + 'WEB-INF/lib'
           @droplet.additional_libraries.each { |additional_library| FileUtils.cp_r additional_library, web_inf_lib }

--- a/spec/java_buildpack/container/jboss_spec.rb
+++ b/spec/java_buildpack/container/jboss_spec.rb
@@ -28,6 +28,12 @@ describe JavaBuildpack::Container::Jboss do
     expect(component.detect).to include("jboss=#{version}")
   end
 
+  it 'detects ear',
+     app_fixture: 'container_tomcat_ear' do
+
+    expect(component.detect).to include("jboss=#{version}")
+  end
+
   it 'does not detect when WEB-INF is absent',
      app_fixture: 'container_main' do
 
@@ -65,6 +71,15 @@ describe JavaBuildpack::Container::Jboss do
     expect(sandbox + 'standalone/deployments/ROOT.war.dodeploy').to exist
   end
 
+  it 'creates a "ROOT.ear.dodeploy" in the deployments directory',
+     app_fixture:   'container_tomcat_ear',
+     cache_fixture: 'stub-jboss.tar.gz' do
+
+    component.compile
+
+    expect(sandbox + 'standalone/deployments/ROOT.ear.dodeploy').to exist
+  end
+
   it 'copies only the application files and directories to the ROOT webapp',
      app_fixture:   'container_tomcat',
      cache_fixture: 'stub-jboss.tar.gz' do
@@ -77,6 +92,22 @@ describe JavaBuildpack::Container::Jboss do
 
     web_inf = root_webapp + 'WEB-INF'
     expect(web_inf).to exist
+
+    expect(root_webapp + '.test-file').not_to exist
+  end
+
+  it 'copies only the ear application files and directories to the ROOT webapp',
+     app_fixture:   'container_tomcat_ear',
+     cache_fixture: 'stub-jboss.tar.gz' do
+
+    FileUtils.touch(app_dir + '.test-file')
+
+    component.compile
+
+    root_webapp = app_dir + '.java-buildpack/jboss/standalone/deployments/ROOT.ear'
+
+    meta_inf = root_webapp + 'META-INF'
+    expect(meta_inf).to exist
 
     expect(root_webapp + '.test-file').not_to exist
   end


### PR DESCRIPTION
Related to open issue #14 (ear support for JBOSS buildpack).

This PR allows a properly packaged ear application (containing a META-INF/applciation.xml) to be pushed to cloud foundry using the JBoss buildpack.  